### PR TITLE
chore: merge `dev` to `main`

### DIFF
--- a/src/components/effects/GlowingBackground.module.scss
+++ b/src/components/effects/GlowingBackground.module.scss
@@ -28,15 +28,4 @@
     transition: 30s;
     transition-property: top, left, transform;
   }
-
-  @media (prefers-contrast: more),
-    (prefers-reduced-transparency: reduce),
-    (prefers-reduced-motion: reduce),
-    print {
-    display: none;
-  }
-
-  [data-theme="light"] & {
-    display: none;
-  }
 }

--- a/src/components/effects/GlowingBackground.tsx
+++ b/src/components/effects/GlowingBackground.tsx
@@ -22,16 +22,20 @@ const GlowingBackground: Component<{
             '(prefers-contrast:more),(prefers-reduced-transparency:reduce),(prefers-reduced-motion:reduce),print',
         )
 
-        setEffectDisabled(prefersNoEffect.matches)
+        const handler = (e: Pick<MediaQueryListEvent, 'matches'>) => {
+            log('log', 'User prefers accessibility options, disabling')
+            setEffectDisabled(e.matches)
+        }
 
-        const handler = (e: MediaQueryListEvent) => setEffectDisabled(e.matches)
+        handler(prefersNoEffect)
+
         prefersNoEffect.addEventListener('change', handler)
         onCleanup(() => prefersNoEffect.removeEventListener('change', handler))
     })
 
     // More conditions to disable effects
     createEffect(() => {
-        if (effectDisabled()) return log('log', 'User prefers accessibility options, disabling')
+        if (effectDisabled()) return
 
         if ('mozInnerScreenX' in window && typeof window.mozInnerScreenX !== 'undefined') {
             // Firefox with low opacity gradient sucks

--- a/src/components/effects/GlowingBackground.tsx
+++ b/src/components/effects/GlowingBackground.tsx
@@ -1,18 +1,9 @@
-import {
-    type Component,
-    For,
-    type JSX,
-    createEffect,
-    onCleanup,
-    onMount,
-    createSignal,
-    useContext,
-} from 'solid-js'
+import { type Component, For, type JSX, createEffect, createSignal, onCleanup, onMount, useContext } from 'solid-js'
 import { Portal } from 'solid-js/web'
 
+import { ThemeContext } from '~/contexts'
 import { logger } from '~/utils'
 import styles from './GlowingBackground.module.scss'
-import { ThemeContext } from '~/contexts'
 
 const GlowingBackground: Component<{
     children: JSX.Element | JSX.Element[]


### PR DESCRIPTION
This merge includes the following changes:

- Minor performance improvements when using `<GlowBackground>`.
  When the background shouldn't be rendered, unused event listeners are automatically cleaned up. They will be re-added once they are needed again.

- Correction of `ThemeContext#colorScheme` when initially initializing `<ThemeProvider>`
  It used to be whatever the default hardcoded value is.
  
- Better debug logging for `<GlowBackground>`
  Self explanatory.