### PR TITLE
chore: merge `dev` to `main`

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -41,13 +41,16 @@ main {
 * {
   box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
+  overscroll-behavior: contain;
   // Fixes precision issues with outline
   outline-offset: -1px;
 }
 
-html {
+:root {
   color-scheme: dark light;
   scroll-behavior: smooth;
+  accent-color: var(--primary);
+  scroll-padding: 6rem;
 }
 
 body {

--- a/src/components/NavDock.module.scss
+++ b/src/components/NavDock.module.scss
@@ -17,7 +17,7 @@
   outline: var(--line-style) transparent;
 
   transition: var(---duration-short);
-  transition-property: background-color, outline-color;
+  transition-property: background-color, outline-color, backdrop-filter;
 
   &:has(.ActiveItem) .Highlight {
     opacity: 1;

--- a/src/components/NavDock.module.scss
+++ b/src/components/NavDock.module.scss
@@ -32,7 +32,7 @@
     }
 
     @media not print and (prefers-contrast: more) and (prefers-reduced-transparency: reduce) and (prefers-reduced-motion: reduce) {
-      backdrop-filter: blur(var(--gap-small));
+      backdrop-filter: blur(var(--gap-small)) brightness(80%);
       background-color: color-mix(in srgb, var(--surface-low), transparent 10%);
 
       & .Highlight {
@@ -43,7 +43,6 @@
         );
       }
     }
-    
   }
 }
 

--- a/src/components/NavDock.tsx
+++ b/src/components/NavDock.tsx
@@ -78,7 +78,7 @@ const NavDock: Component<NavDockProps> = props => {
                                                 href: page.href,
                                                 inactiveClass: '',
                                                 activeClass: styles.ActiveItem,
-                                                end: true,
+                                                end: !page.matchSubroutes,
                                                 onClick: e => {
                                                     if (
                                                         !(e.currentTarget as HTMLAnchorElement).classList.contains(
@@ -180,4 +180,5 @@ interface LinkConfig {
     icon: IconType
     href: string
     name: string
+    matchSubroutes?: boolean
 }

--- a/src/components/Page.module.scss
+++ b/src/components/Page.module.scss
@@ -78,6 +78,10 @@
   gap: var(--gap-insanely-large);
 }
 
+.G-rm {
+  gap: var(--gap-relative-medium);
+}
+
 .G-rsm {
   gap: var(--gap-relative-small);
 }

--- a/src/components/Page.module.scss
+++ b/src/components/Page.module.scss
@@ -7,6 +7,9 @@
 }
 
 :global(#content) {
+  width: 100%;
+  // TODO: Put these as a constant?
+  max-width: 44rem;
   padding: var(--gap-larger);
 
   // Mobile will have larger padding so it isn't as close to screen edges
@@ -17,13 +20,13 @@
   align-items: stretch;
 }
 
-// TODO: Put these as a constant?
 .Section {
-  max-width: 40rem;
+  // TODO: Put these as a constant?
   padding-block: min(4vh, var(--gap-larger));
 }
 
-.FH-Row, .FH-Col {
+.FH-Row,
+.FH-Col {
   display: flex;
 }
 

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -9,7 +9,7 @@ import styles from './Page.module.scss'
 export const Page: Component<ComponentProps<'main'>> = props => {
     return (
         <Column as="main" flex centerHorizontal {...props} tabIndex="-1">
-            <Column flex centerHorizontal id="content">
+            <Column centerHorizontal id="content">
                 {props.children}
             </Column>
         </Column>

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -91,7 +91,7 @@ export type FlexHelperProps<E extends ElementType> = FlexHelperCustomProps<E> &
 type FlexHelperCustomProps<E extends ElementType> = {
     as?: E
     asProps?: ComponentProps<E>
-    gap?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl' | 'rsm' | 'rxs'
+    gap?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl' | 'rsm' | 'rxs' | 'rm'
     flex?: boolean
     wrap?: boolean
     centerVertical?: boolean

--- a/src/components/buttons/Button.module.scss
+++ b/src/components/buttons/Button.module.scss
@@ -1,4 +1,5 @@
 .Base {
+  width: fit-content;
   text-align: center;
   padding: var(--gap-small) var(--gap-small);
   border-radius: var(--radius-medium);

--- a/src/routes/(layout).tsx
+++ b/src/routes/(layout).tsx
@@ -13,7 +13,7 @@ const Layout: Component<RouteSectionProps> = props => {
             <NavDock
                 pages={[
                     { name: 'Home', href: '/', icon: IconHome },
-                    { name: 'Blog', href: '/blog', icon: IconBlog },
+                    { name: 'Blog', href: '/blog', icon: IconBlog, matchSubroutes: true },
                 ]}
                 links={[
                     {

--- a/src/routes/(layout)/(home).module.scss
+++ b/src/routes/(layout)/(home).module.scss
@@ -4,7 +4,6 @@
   display: grid;
   grid-template-columns: 1.5fr 0.75fr 0.25fr 1.5fr;
   grid-template-rows: 1fr 0.25fr;
-  max-width: 48rem;
   gap: var(--gap-small);
   grid-template-areas:
     "a b b b"

--- a/src/routes/(layout)/(home).tsx
+++ b/src/routes/(layout)/(home).tsx
@@ -81,7 +81,7 @@ export default (() => {
                                     <Touchable
                                         as={Row}
                                         asProps={{
-                                            gap: 'sm',
+                                            gap: 'xs',
                                             as: 'a',
                                             href: skill.link,
                                             target: '_blank',

--- a/src/routes/(layout)/blog/index.tsx
+++ b/src/routes/(layout)/blog/index.tsx
@@ -8,7 +8,7 @@ import sharedStyles from '~/styles/shared.module.scss'
 export default (() => {
     return (
         <Page>
-            <Section constrainSize>
+            <Section centerHorizontal constrainSize>
                 <Column gap="none" class={sharedStyles.DirectTextChildrenAlignCenter}>
                     {/* biome-ignore lint/a11y/useHeadingContent: Screen readers kinda suck, so here's a workaround */}
                     <h1 aria-label="Coming soon">

--- a/src/styles/constants.scss
+++ b/src/styles/constants.scss
@@ -11,6 +11,7 @@
   // Relative gaps
   --gap-relative-smaller: 0.125em;
   --gap-relative-small: 0.5em;
+  --gap-relative-medium: 1em;
 
   // Sizes
   --size-smaller: 1rem;

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -5,6 +5,7 @@
 
 :root {
   --line-height: 1.5;
+  --line-height-heading: 1.2;
 
   --text-display: 3.5em;
   --text-title: 2.5em;
@@ -49,6 +50,7 @@ h6 {
 h1,
 h2,
 h3 {
+  line-height: var(--line-height-heading);
   color: var(--neutral-high);
   text-wrap: balance;
 }


### PR DESCRIPTION
This pull request introduces these new features:

- New relative gap constant (`--gap-relative-medium`)
  - ~~Needs to be added to flex helpers~~ (FIXED)
- Option for links on `<NavDock>` to match subroutes as well
- Improved styling with new CSS properties
- Increased `<NavDock>`'s highlight contrast by lowering the brightness of the backdrop
  - ~~This introduces an issue where when in transition, the dock has a black color before finally fading to the right color~~ (FIXED)
- Decreased line height for large headings
  
There are also some fixes:

- Decreased gap between icon and name in skill chip
- Buttons do not fill whole width anymore